### PR TITLE
[WIP] Adding snapshot flexibility for local_circuit_simulator

### DIFF
--- a/qiskit/aqua/operators/circuit_samplers/local_simulator_sampler.py
+++ b/qiskit/aqua/operators/circuit_samplers/local_simulator_sampler.py
@@ -104,7 +104,7 @@ class LocalSimulatorSampler(CircuitSampler):
     def convert(self,
                 operator: OperatorBase,
                 params: dict = None,
-                return_snapshots = False):
+                return_snapshots: bool = False):
         if self._last_op is None or not operator == self._last_op:
             # Clear caches
             self._last_op = operator

--- a/qiskit/aqua/operators/circuit_samplers/local_simulator_sampler.py
+++ b/qiskit/aqua/operators/circuit_samplers/local_simulator_sampler.py
@@ -130,8 +130,8 @@ class LocalSimulatorSampler(CircuitSampler):
 
         # Don't pass circuits if we have in the cache the sampling function knows to use the cache.
         circs = list(self._circuit_ops_cache.values()) if not self._transpiled_circ_cache else None
-        sampled_statefn_dicts, snapshot_data  = self.sample_circuits(op_circuits=circs,
-                                                     param_bindings=param_bindings)
+        sampled_statefn_dicts, snapshot_data = self.sample_circuits(op_circuits=circs,
+                                                                    param_bindings=param_bindings)
 
         def replace_circuits_with_dicts(operator, param_index=0):
             if isinstance(operator, CircuitStateFn):
@@ -143,10 +143,10 @@ class LocalSimulatorSampler(CircuitSampler):
                 return operator
         return_op = None
         if params:
-            return_op =  ListOp([replace_circuits_with_dicts(self._reduced_op_cache, param_index=i)
+            return_op = ListOp([replace_circuits_with_dicts(self._reduced_op_cache, param_index=i)
                                 for i in range(num_parameterizations)])
         else:
-            return_op =  replace_circuits_with_dicts(self._reduced_op_cache, param_index=0)
+            return_op = replace_circuits_with_dicts(self._reduced_op_cache, param_index=0)
 
         if return_snapshots:
             return return_op, snapshot_data
@@ -215,7 +215,7 @@ class LocalSimulatorSampler(CircuitSampler):
                     result_sfn = StateFn(op_c.coeff * results.get_statevector(circ_index))
                     c_statefns.append(result_sfn)
                     continue
-                elif 'snapshots' in results.data(circ_index):
+                if 'snapshots' in results.data(circ_index):
                     snapshots = results.data(circ_index)['snapshots']
                     snapshot_data[i][j] = snapshots
                     print(snapshot_data)
@@ -232,7 +232,7 @@ class LocalSimulatorSampler(CircuitSampler):
                         continue
 
                 result_sfn = StateFn({b: (v * op_c.coeff / self._qi._run_config.shots) ** .5
-                                          for (b, v) in results.get_counts(circ_index).items()})
+                                      for (b, v) in results.get_counts(circ_index).items()})
                 c_statefns.append(result_sfn)
             sampled_statefn_dicts[id(op_c)] = c_statefns
         return sampled_statefn_dicts, snapshot_data

--- a/qiskit/aqua/operators/circuit_samplers/local_simulator_sampler.py
+++ b/qiskit/aqua/operators/circuit_samplers/local_simulator_sampler.py
@@ -218,7 +218,6 @@ class LocalSimulatorSampler(CircuitSampler):
                 if 'snapshots' in results.data(circ_index):
                     snapshots = results.data(circ_index)['snapshots']
                     snapshot_data[i][j] = snapshots
-                    print(snapshot_data)
                     if 'expectation_value' in snapshots:
                         avg = snapshots['expectation_value']['expval'][0]['value']
                         if isinstance(avg, (list, tuple)):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The way the `local_circuit_simulator` handles snapshots can easily be broken. The `sample_circuit` method can fail if you add unexpected snapshots or if you fail to include snapshots in your circuit. 

This PR addresses these changes by adding support for arbitrary snapshot instructions. Thought still needs to be put into the right way to handle this is, but this PR is a start and it's enough to unblock me on the project I'm working on. 

### Details and comments
The `CircuitSampler._snapshot `variable is automatically set to true if `is_aer_qasm(backend)==True`. This is a problem. In my situation, I simply needed to take a few samples from an input circuit in various pauli eigenbases. I was not taking an expectation value, so I included no snapshot_expectation_value instructions in my circuits, however, the `._snapshot` variable was set to `True` simply because I was using the qasm simulator. This broke the `sample_circuit` function as it went to go look for the `'snapshot'` entry of the results dict and got a key error. 

Additionally, I needed to add a `'density_matrix'` snapshot to my circuits at the end, but the `sample_circuit` function was hard-coded to expect `'expectation_value'` snapshots. 

My solution to this was to have `sample_circuits` return both the `sampled_statefn_dicts` and a second argument, `snapshot_data`, containing all of the snapshots returned by Aer. 

Subsequently, the `convert` function was given a boolean argument, `return_snapshots` which controls whether or not the raw snapshot data is returned. 

If `return_snapshots==True` but no snapshots are included in the CircuitStateFn's, then an empty dict is returned. 
